### PR TITLE
Cleaned up bash scripts according to shellcheck errors

### DIFF
--- a/bin/first-build.sh
+++ b/bin/first-build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 git submodule foreach bash -c 'git checkout develop'
-find . -name '*.example' -not -path '*apollo*' | while read f; do cp "$f" "${f%%.example}"; done
+find . -name '*.example' -not -path '*apollo*' | while read -r f; do cp "$f" "${f%%.example}"; done
 docker-compose build
 docker-compose up --abort-on-container-exit

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -20,7 +20,7 @@ release() {
 
   git submodule foreach -q "
     echo Checking version $version for submodule \$name.;
-    if git rev-parse "$version" >/dev/null 2>&1; then
+    if git rev-parse $version >/dev/null 2>&1; then
       echo \$name will be updated.
       git checkout -q $version
     else
@@ -31,7 +31,7 @@ release() {
 
   git add -u
   git commit -m "Updated submodules to $version"
-  git tag $version
+  git tag "$version"
   git show
 
   echo -e "\n***** Release $version is ready *****\n"

--- a/bin/tar-config.sh
+++ b/bin/tar-config.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 
 # config tarfile is suffixed with timestamp.
-filename=config-`date +%Y%m%d%H%M`.tar.gz
+filename=config-$(date +%Y%m%d%H%M).tar.gz
 
 # find all config files, which should have .example variants.
-configs=`find . -name '*.example'`
+configs=$(find . -name '*.example')
 configs=${configs//.example/}
 
 # attempt to tar each file, but don't fail on missing ones.
 # http://unix.stackexchange.com/questions/167717/tar-a-list-of-files-which-dont-all-exist
-tar zcf $filename $(ls $configs 2>/dev/null)
+tar zcf "$filename" "$(ls "$configs" 2>/dev/null)"
 
 # fail on non-zero exit code.
-if [ $? -eq 0 ]
+if tar zcf "$filename" "$(ls "$configs" 2>/dev/null)"
 then
-  echo Created file $filename
+  echo Created file "$filename"
   exit 0
 else
-  rm $filename
-  echo Could not create file $filename
+  rm "$filename"
+  echo Could not create file "$filename"
   exit 1
 fi

--- a/bin/tar-config.sh
+++ b/bin/tar-config.sh
@@ -9,9 +9,6 @@ configs=${configs//.example/}
 
 # attempt to tar each file, but don't fail on missing ones.
 # http://unix.stackexchange.com/questions/167717/tar-a-list-of-files-which-dont-all-exist
-tar zcf "$filename" "$(ls "$configs" 2>/dev/null)"
-
-# fail on non-zero exit code.
 if tar zcf "$filename" "$(ls "$configs" 2>/dev/null)"
 then
   echo Created file "$filename"


### PR DESCRIPTION
Hey!

I went ahead and ran `shellcheck` on the bash scripts located in the "bin" directory and made some corrections according to the errors given by `shellcheck`.

Majority of the changes that were made were basic things such as adding double quouts around variables, using `$()` instead of the legacy backticks. 