### PR TITLE
Check 2147 Support for m 1 mac dockerized development environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - until curl --silent -I -f --fail http://localhost:3000 ; do printf .; sleep 1; done
   - sleep 120
   - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:3200)!= "200" ));  then exit 1; fi;
-  - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:5000)!= "200" ));  then exit 1; fi;
+  - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:3100)!= "200" ));  then exit 1; fi;
   - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:3333)!= "200" ));  then exit 1; fi;
   - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000)!= "200" ));  then exit 1; fi;
   - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:8001)!= "200" ));  then exit 1; fi;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ networks:
 services:
   elasticsearch:
     build: alegre/elasticsearch
+    platform: linux/x86_64
     environment:
       discovery.type: single-node
       transport.host: 127.0.0.1
@@ -31,6 +32,7 @@ services:
       - dev
   postgres:
     build: ./alegre/postgres
+    platform: linux/x86_64
     ports:
       - "5432:5432"
     volumes:
@@ -106,6 +108,7 @@ services:
       - dev
   pender:
     build: pender
+    platform: linux/x86_64
     shm_size: 1G
     ports:
       - "3200:3200"
@@ -122,6 +125,7 @@ services:
       - dev
   pender-background:
     build: pender
+    platform: linux/x86_64
     command: /app/docker-background.sh
     shm_size: 1G
     volumes:
@@ -135,6 +139,7 @@ services:
       - dev
   web:
     build: check-web
+    platform: linux/x86_64
     ports:
       - "3333:3333"
     depends_on:
@@ -164,6 +169,7 @@ services:
       - dev
   alegre:
     build: alegre
+    platform: linux/x86_64
     ports:
       - "5000:5000"
     volumes:
@@ -177,6 +183,7 @@ services:
       - dev
   queue_worker:
     build: alegre
+    platform: linux/x86_64
     command: ["make", "run_rq_worker"]
     volumes:
       - "./alegre:/app"
@@ -253,6 +260,7 @@ services:
 #      - dev
   bots:
     build: check-bots
+    platform: linux/x86_64
     volumes:
       - "./check-bots:/app"
       - "bots-node_modules:/app/node_modules"
@@ -267,6 +275,7 @@ services:
       - dev
   check-slack-bot:
     build: check-slack-bot
+    platform: linux/x86_64
     volumes:
       - "./check-slack-bot:/app"
       - "/app/node_modules"
@@ -277,6 +286,7 @@ services:
       - dev
   narcissus:
     build: narcissus
+    platform: linux/x86_64
     shm_size: 1G
     volumes:
       - "./narcissus:/app"
@@ -295,6 +305,7 @@ services:
     volumes:
       - "./fetch:/app"
     build: fetch
+    platform: linux/x86_64
     depends_on:
       - elasticsearch
       - redis
@@ -308,6 +319,7 @@ services:
   fetch-background:
     volumes:
       - "./fetch:/app"
+    platform: linux/x86_64
     depends_on:
       - elasticsearch
       - kibana
@@ -320,6 +332,7 @@ services:
       - dev
   mark:
     build: check-mark
+    platform: linux/x86_64
     volumes:
       - "./check-mark:/app"
       - "./check-api:/api"
@@ -329,6 +342,7 @@ services:
       - dev
   search:
     build: check-search
+    platform: linux/x86_64
     volumes:
       - "./check-search:/app"
       - "/app/node_modules"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ networks:
 services:
   elasticsearch:
     build: alegre/elasticsearch
-    platform: linux/x86_64
     environment:
       discovery.type: single-node
       transport.host: 127.0.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,7 +171,7 @@ services:
     build: alegre
     platform: linux/x86_64
     ports:
-      - "5000:5000"
+      - "3100:3100"
     volumes:
       - "./alegre:/app"
     depends_on:

--- a/docker-test.yml
+++ b/docker-test.yml
@@ -50,7 +50,7 @@ services:
   alegre:
     environment:
       BOILERPLATE_ENV: test
-      ALEGRE_PORT: 5000
+      ALEGRE_PORT: 3100
       REDIS_DATABASE: 3
   narcissus:
     environment:


### PR DESCRIPTION
Changes needed to get development environment running on M1 macs - will open other PRs on branches in other relevant repositories.

* Conservatively specify platform as linux/x86_64 in docker-compose so that we use the emulator / they don’t try to build every image on arm arc
* Allow for Docker image to build as it wants to for the api & api-background where the [Docker amd emulator has bugs on M1](https://github.com/docker/for-mac/issues/5321) (was getting errors for inotify). 
* Change alegre port to 3100 (from 5000), since [port 5000 is now in use on Macs running Monterey](https://developer.apple.com/forums/thread/682332). It looks like it was 3100 at some point in past but [changed for consistency](https://github.com/meedan/check/pull/60/files); I’m intending on changing it to 3100 everywhere to try to prevent future confusion (vs just port-forwarding 5000 → 3100).

I marked this PR as draft so that it doesn't get accidentally merged before Aaron's review and the submodule bumps once the dependent PRs are merged. But I don't intend on making any changes other than that unless they're needed.