### PR TITLE
Add configurator instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This is a [Docker Compose](https://docs.docker.com/compose/) configuration that 
 - Click "I already have an account" and login using your credentials
 - Enjoy Check! :tada:
 
+**Note:** As you run the applications you may need credentials and configuration that are not provided by copying `.example` files during the initial build. To provide these you can run [`configurator`](https://github.com/meedan/configurator) according to its README for the environment you want to run (`local` for development or `travis` for tests).
+
 ## Available services and container names
 
 - Check web client (container `web`) at [http://localhost:3333](http://localhost:3333)


### PR DESCRIPTION
I was missing context on this step during onboarding until Daniele told me about it! Thought it would be helpful to have some instructions about fetching credentials and config along with our other getting started steps.

I could use a pair of eyes to make sure 1) we want to include this in readme, and 2) that I described the `local` and `travis` environment usage correctly.