### PR TITLE
Add postgres as development and test dep for Pender

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,7 @@ services:
     volumes:
       - "./pender:/app"
     depends_on:
+      - postgres
       - redis
       - minio
     environment:


### PR DESCRIPTION
We are no longer using sqlite in development and test, and instead are using Postgres to more closely model the deployed environments.

CV2-2668