### PR TITLE
Update testing documentation for Check API and Pender

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,15 @@ This is a [Docker Compose](https://docs.docker.com/compose/) configuration that 
 - Fetch: `docker-compose exec fetch bundle exec rake test`
 - Running a specific Check Web test: `docker-compose exec web bash -c "cd test && rspec --example KEYWORD spec/integration_spec.rb"`
 - Running a specific Check Mark test: `docker-compose exec mark bash -c "cd test && rspec --example KEYWORD spec/app_spec.rb"`
-- Running a specific Check API or Pender test (from within the container): `bundle exec ruby -I"lib:test" test/path/to/specific_test.rb -n /.*KEYWORD.*/`
+
+- Running Check API or Pender tests:
+  - Pender or Check API tests can be run from development containers (e.g. from `check` directory run `docker-compose up api pender`). They do not need to be run in a "test mode" container, allowing us to run unit tests while having a browser connected to the development server. These tests run against a different database than development, so your development data will be preserved. More on testing Rails with Minitest, the testing framework we use for most of our application, can be found [here](https://guides.rubyonrails.org/testing.html), including [directions about managing the test database](https://guides.rubyonrails.org/testing.html#the-test-database).
+  - First, connect to the dev container: from `check` directory, `docker-compose exec <service name (pender, api)> bash`
+  - From within dev container:
+    - Running all tests: `bin/rails test`
+    - Running a specific test: `bin/rails test <path/to/test/file/in/check-api>.rb:<test-line-number> (e.g. bin/rails test test/controllers/graphql_controller_test.rb:18)`)
+      - Note: it may be helpful to comment out code coverage and retries from `test_helper.rb` when running individual tests frequently, as they will not be automatically disabled.
+
 
 ## Helpful one-liners and scripts
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This is a [Docker Compose](https://docs.docker.com/compose/) configuration that 
   - First, connect to the dev container: from `check` directory, `docker-compose exec <service name (pender, api)> bash`
   - From within dev container:
     - Running all tests: `bin/rails test`
-    - Running a specific test: `bin/rails test <path/to/test/file/in/check-api>.rb:<test-line-number> (e.g. bin/rails test test/controllers/graphql_controller_test.rb:18)`)
+    - Running a specific test: `bin/rails test <path/to/test/file/in/check-api>.rb:<test-line-number>` (e.g. `bin/rails test test/controllers/graphql_controller_test.rb:18`)
       - Note: it may be helpful to comment out code coverage and retries from `test_helper.rb` when running individual tests frequently, as they will not be automatically disabled.
 
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ This is a [Docker Compose](https://docs.docker.com/compose/) configuration that 
 - Start the app in test mode: `docker-compose -f docker-compose.yml -f docker-test.yml up`
 - Check web client: `docker-compose exec web npm run test`
 - Check browser extension: `docker-compose -f docker-compose.yml -f docker-test.yml exec geckodriver bash -c "cd /home && chown -R  root seluser" && docker-compose exec mark npm run test`
-- Check service API: `docker-compose exec api bundle exec rake test`
-- Pender service API: `docker-compose exec pender bundle exec rake test`
 - Check Slack Bot: `docker-compose exec check-slack-bot npm run test`
 - Narcissus: `docker-compose exec narcissus npm run test`
 - Fetch: `docker-compose exec fetch bundle exec rake test`


### PR DESCRIPTION
This updates the Check documentation to make it clearer how to run Check API and Pender tests without spinning up a separate test container. Would love a read through to see if this is clear and makes sense!

Related thought: We may want to add documentation about integration tests (or links to our confluence pages), but that seemed out of scope for this PR. I think we need additional work to support running them locally with these changes, but it's hard for me to test since I can't run integration tests locally.