### PR TITLE
Adding Presto to Check

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,6 +28,11 @@
   url = git@github.com:meedan/alegre.git
   branch = develop
   ignore = all
+[submodule "presto"]
+  path = presto
+  url = git@github.com:meedan/presto
+  branch = master
+  ignore = all
 [submodule "check-bots"]
   path = check-bots
   url = git@github.com:meedan/check-bots.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,7 +30,7 @@
   ignore = all
 [submodule "presto"]
   path = presto
-  url = git@github.com:meedan/presto
+  url = git@github.com:meedan/presto.git
   branch = master
   ignore = all
 [submodule "check-bots"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: jammy
 git:
   submodules: false
 before_script:
@@ -8,18 +8,19 @@ before_script:
   - sed -i 's/--abort-on-container-exit/-d/' bin/first-build.sh
   - TAB=$'\t'
   # For each submodule, go to a branch with the same name as this branch
-  - export FALLBACK_BRANCH=$([ "$TRAVIS_BRANCH" == "master" ] && echo "main" || echo "develop")
-  - git submodule foreach 'bash -c "git checkout develop ; git checkout $FALLBACK_BRANCH ; git checkout $TRAVIS_BRANCH ; exit 0"'
+  - export FALLBACK_BRANCH=$([ "$TRAVIS_BRANCH" == "master" ] && echo "main" && echo "master" || echo "develop")
+  - git submodule foreach 'bash -c "git checkout master ; git checkout develop ; git checkout $FALLBACK_BRANCH ; git checkout $TRAVIS_BRANCH ; exit 0"'
   - git submodule foreach git rev-parse --abbrev-ref HEAD
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 script:
   - ./bin/first-build.sh
   - until curl --silent -I -f --fail http://localhost:3000 ; do printf .; sleep 1; done
   - sleep 120
-  - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:3200)!= "200" ));  then exit 1; fi; # Pender
-  - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:3100)!= "200" ));  then exit 1; fi; # Alegre
-  - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:3333)!= "200" ));  then exit 1; fi; # Check Web
-  - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000)!= "200" ));  then exit 1; fi; # Check API
+  - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:3200)!= "200" )); then exit 1; fi; # Pender
+  - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:3100)!= "200" )); then exit 1; fi; # Alegre
+  - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/ping)!= "200" )); then exit 1; fi; # Presto
+  - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:3333)!= "200" )); then exit 1; fi; # Check Web
+  - if (( $(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000)!= "200" )); then exit 1; fi; # Check API
   - docker ps --format '{{.Image}}' | sort >> docker_up_output.txt
   - diff docker_up_output.txt test/image_names.txt
 notifications:

--- a/bin/first-build.sh
+++ b/bin/first-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Go to the develop branch of each repository
-git submodule foreach bash -c 'git checkout develop'
+git submodule foreach bash -c 'git checkout develop || git checkout master'
 
 # Copy the example files
 find . -name '*.example' -not -path '*apollo*' | while read f; do cp "$f" "${f%%.example}"; done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,18 @@ services:
       MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
     networks:
       - dev
+  elasticmq:
+    image: softwaremill/elasticmq
+    hostname: presto-elasticmq
+    ports:
+      - "9324:9324"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-S", "-O", "-", "127.0.0.1:9324/?Action=ListQueues"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dev
   api:
     build: check-api
     mem_limit: 4g
@@ -167,6 +179,20 @@ services:
       ELASTICSEARCH_URL: http://elasticsearch:9200
     networks:
       - dev
+  presto:
+    build: presto
+    platform: linux/amd64
+    ports:
+      - "8000:8000"
+    volumes:
+      - "./presto:/app"
+    env_file:
+      - presto/.env_file
+    networks:
+      - dev
+    depends_on:
+      elasticmq:
+        condition: service_healthy
   alegre:
     build: alegre
     platform: linux/x86_64
@@ -178,6 +204,7 @@ services:
       - postgres
       - redis
       - elasticsearch
+      - presto
     env_file:
       - alegre/.env_file
     networks:

--- a/docker-test.yml
+++ b/docker-test.yml
@@ -52,6 +52,11 @@ services:
       BOILERPLATE_ENV: test
       ALEGRE_PORT: 3100
       REDIS_DATABASE: 3
+  presto:
+    environment:
+      BOILERPLATE_ENV: test
+      PRESTO_PORT: 8000
+      REDIS_DATABASE: 3
   narcissus:
     environment:
       NODE_ENV: development

--- a/test/image_names.txt
+++ b/test/image_names.txt
@@ -8,8 +8,10 @@ check_narcissus
 check_pender
 check_pender-background
 check_postgres
+check_presto
 check_queue_worker
 check_web
 docker.elastic.co/kibana/kibana:7.9.2
 minio/minio
 redis:5
+softwaremill/elasticmq


### PR DESCRIPTION
This PR adds Presto to Check as a Git Submodule. It also adds the service and its dependency ElasticMQ to Docker Compose. This way, we're able to run Presto locally as part of the Check suite. More details added as comments to the PR, see "Files changed".