### PR TITLE
3480 – Upgrade redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     networks:
       - dev
   redis:
-    image: redis:5
+    image: redis:6.2
     ports:
       - "6379:6379"
     volumes:

--- a/test/image_names.txt
+++ b/test/image_names.txt
@@ -13,5 +13,5 @@ check_queue_worker
 check_web
 docker.elastic.co/kibana/kibana:7.9.2
 minio/minio
-redis:5
+redis:6.2
 softwaremill/elasticmq


### PR DESCRIPTION
### Description

We are upgrading Sidekiq in Pender [[PR](https://github.com/meedan/pender/pull/416)], in order to do so we need to upgrade Redis.

References: 3480

### How has this been tested?

By running integration tests on check-web.