### PR TITLE
CV2-4136-timpani-accessible-yake-keyword-mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -247,6 +247,21 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+  presto-yake:
+    build: presto
+    platform: linux/amd64
+    volumes:
+      - "./presto:/app"
+    env_file:
+      - presto/.env_file
+    environment:
+      ROLE: worker
+      MODEL_NAME: yake_keywords.Model
+    networks:
+      - dev
+    depends_on:
+      elasticmq:
+        condition: service_healthy
   alegre:
     build: alegre
     platform: linux/x86_64


### PR DESCRIPTION
PR to add `presto-yake` to `docker-compose.yml` to support development of yake keywords model in Presto.
Reference: https://meedan.atlassian.net/browse/CV2-4136 