### PR TITLE
Specify chromedriver platform in docker-test.yml

### DIFF
--- a/docker-test.yml
+++ b/docker-test.yml
@@ -5,6 +5,7 @@ networks:
 services:
   chromedriver:
     build: check-web/chromedriver
+    platform: "linux/amd64"
     ports:
       - 5900:5900
       - 4444:4444


### PR DESCRIPTION
Last week I started running into an error when running the `git-update.sh` script.
The issue happened when it got to: `docker compose -f docker-compose.yml -f docker-test.yml build`

The error:
```
failed to solve: selenium/standalone-chrome:125.0: failed to resolve source metadata for docker.io/selenium/standalone-chrome:125.0: no match for platform in manifest: not found
```

Specifying the platform in the `docker-test.yml` file fixed this for me.

**Note and Thanks** ❤️ 
@amoedoamorim helped me with this one, he might be able to give some more context if needed.