### PR TITLE
Allow Check API containers to connect to the host machine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,8 @@ services:
       SERVER_PORT: 3000
     networks:
       - dev
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   api-background:
     build: check-api
     command: /app/docker-background.sh
@@ -122,6 +124,8 @@ services:
       SERVER_PORT: 3000
     networks:
       - dev
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   pender:
     build: pender
     platform: linux/x86_64


### PR DESCRIPTION
In order to test sending emails locally, we're experimenting with MailCatcher. So, if MailCatcher is running in the host machine, Check API containers should be able to connect to them. This is possible by adding `extra_hosts` to the Check API containers in Docker Compose.