### PR TITLE
6473 add otel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This is a [Docker Compose](https://docs.docker.com/compose/) configuration that 
 - Narcissus screenshot service (container `narcissus`) at [http://localhost:8687](http://localhost:8687)
 - Fetch fact-checking service (container `fetch`) at [http://localhost:8687/about](http://localhost:8687/about)
 - Search v2 prototype application (container `search`) at [http://localhost:8001](http://localhost:8001)
+- Otel Collector – you can configure receivers, processors and exporters in the otel-collector-config.yaml
 
 ## Testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,8 +126,8 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   pender:
-    env_file:
-      - ./pender/.env
+    # env_file:
+    #   - ./pender/.env
     build: pender
     platform: linux/x86_64
     shm_size: 1G

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,7 @@ services:
       SERVER_PORT: 3200
     networks:
       - dev
+  # If you want to run the OpenTelemetry Collector, uncomment the lines below
   # otel-collector:
   #   image: otel/opentelemetry-collector-contrib
   #   volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       - "host.docker.internal:host-gateway"
   pender:
     env_file:
-      - .env
+      - ./pender/.env
     build: pender
     platform: linux/x86_64
     shm_size: 1G

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,8 +165,9 @@ services:
   # otel-collector:
   #   image: otel/opentelemetry-collector-contrib
   #   volumes:
-  #     - ./pender/config/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
+  #     - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
   #   environment:
+  #     x_honeycomb_team: ${X_HONEYCOMB_TEAM} # Set this env var in your shell before running docker-compose
   #     RAILS_ENV: development
   #     SERVER_PORT: 3200
   #   networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,8 +166,6 @@ services:
   #   image: otel/opentelemetry-collector-contrib
   #   volumes:
   #     - ./pender/config/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
-  #   depends_on:
-  #     - pender
   #   environment:
   #     RAILS_ENV: development
   #     SERVER_PORT: 3200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,8 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   pender:
+    env_file:
+      - .env
     build: pender
     platform: linux/x86_64
     shm_size: 1G

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -1,0 +1,35 @@
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "prometheus"
+          scrape_interval: 15s
+          static_configs:
+            - targets: ["pender:3200"]
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 20
+  batch:
+    timeout: 200ms
+    send_batch_size: 8192
+
+exporters:
+  otlp/metrics:
+    endpoint: "api.honeycomb.io:443" # US instance
+    #endpoint: "api.eu1.honeycomb.io:443" # EU instance
+    headers:
+      "x-honeycomb-team": ${env:x_honeycomb_team} # Honeycomb API KEY
+      "x-honeycomb-dataset": "pender"
+
+service:
+  # telemetry:
+  #   logs:
+  #     level: "debug"
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/metrics]


### PR DESCRIPTION
We are using the otel-collector mainly to be able to collect custom metrics from our Rails services. But it is a service that can be used with any of Check's services.

Because it is relevant to all of our services we don't want to keep it in individual repos, but keep it in the main Check one.

This is only relevant to local development.

References: CV2-6473, CV2-4396
Relates to: https://github.com/meedan/pender/pull/586
