### PR TITLE
Disable spring

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,7 @@ services:
       DEPLOY_ENV: local
       RAILS_ENV: development
       SERVER_PORT: 3200
+      DISABLE_SPRING: 1
     networks:
       - dev
   pender-background:


### PR DESCRIPTION
I think there is some weirdness because of our mount bind. When running
from the pender repo it works well, but when running from the check repo
we hit: Error connecting to Spring server.

I tried setting the SPRING_SOCKET and SPRING_TMP_PATH, but couldn't
get it to work. So I suggest disabling spring when running tests from the 
check repo.

CV2-6431
