### PR TITLE
disable tls for internal scrape targets

### DIFF
--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -7,6 +7,8 @@ receivers:
           static_configs:
             - targets: ["${env:pender_metrics_endpoint}"]
           metrics_path: /metrics
+          tls_config:
+            insecure_skip_verify: true
 
 processors:
   memory_limiter:


### PR DESCRIPTION
disables TLS for otel collector container, meant to be hooked up to prometheus metrics endpoints accessed via internal network