### PR TITLE
Migrate to GitHub runners for future deployments

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -16,8 +16,7 @@ permissions:
 
 jobs:
   check-script:
-    runs-on: 
-        labels: check
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description
This change promotes the usage of GitHub Runners rather than a self-hosted EC2 instance running in our AWS account

[Reference](https://meedan.atlassian.net/browse/IS-87)

## How has this been tested?
There is no practical way to test locally, but I've been observing the self-hosted runner CPU/Memory consumption for the last deployments, and we should be fine with the regular GitHub Actions runner

## Have you considered secure coding practices when writing this code?
N/A
